### PR TITLE
Feat/disinherit auth request objects

### DIFF
--- a/KeycloakAgrocatIntegration/Classes/AuthService.cs
+++ b/KeycloakAgrocatIntegration/Classes/AuthService.cs
@@ -13,13 +13,13 @@ namespace KeycloakIntegration
 
         public AuthResponse Login(LoginRequest request)
         {
-            try { return Auth(request); }
+            try { return Auth(request.ToAuthRequest()); }
             catch (AuthException ex) { throw ex; }
         }
 
         public AuthResponse Refresh(RefreshRequest request)
         {
-            try { return Auth(request); }
+            try { return Auth(request.ToAuthRequest()); }
             catch (AuthException ex) { throw ex; }
         }
 

--- a/KeycloakAgrocatIntegration/Classes/LoginRequest.cs
+++ b/KeycloakAgrocatIntegration/Classes/LoginRequest.cs
@@ -1,23 +1,21 @@
-﻿using System;
-namespace KeycloakIntegration.Classes
+﻿namespace KeycloakIntegration.Classes
 {
-	public class LoginRequest : AuthRequest
+	public class LoginRequest
 	{
 
-		public new string? Username {
-			get => base.Username;
-			set => base.Username = value;
-		}
+		public string? Username { get; set; }
+		public string? Password { get; set; }
 
-		public new string? Password
-		{
-			get => base.Password;
-			set => base.Password = value;
-		}
+		public LoginRequest() { }
 
-		public LoginRequest()
+		public AuthRequest ToAuthRequest()
 		{
-			GrantType = "password";
+			return new AuthRequest()
+			{
+				Username = this.Username,
+				Password = Password,
+				GrantType = "password"
+			};
 		}
 
 	}

--- a/KeycloakAgrocatIntegration/Classes/RefreshRequest.cs
+++ b/KeycloakAgrocatIntegration/Classes/RefreshRequest.cs
@@ -1,18 +1,19 @@
-﻿using System;
-namespace KeycloakIntegration.Classes
+﻿namespace KeycloakIntegration.Classes
 {
-	public class RefreshRequest : AuthRequest
+	public class RefreshRequest
 	{
 
-		public new string? RefreshToken
-		{
-			get => base.RefreshToken;
-			set => base.RefreshToken = value;
-		}
+		public string? RefreshToken { get; set; }
 
-		public RefreshRequest()
+		public RefreshRequest() { }
+
+		public AuthRequest ToAuthRequest()
 		{
-			GrantType = "refresh_token";
+			return new AuthRequest()
+			{
+				GrantType = "refresh_token",
+				RefreshToken = this.RefreshToken
+			};
 		}
 
 	}

--- a/KeycloakTester/Controllers/AuthController.cs
+++ b/KeycloakTester/Controllers/AuthController.cs
@@ -42,14 +42,14 @@ namespace KeycloakTester.Controllers
 
         }
 
-        [HttpPost("")]
+        [HttpPost("login")]
         public IActionResult Login(LoginRequest request)
         {
             try { return Ok(auth.Login(request)); }
             catch(Exception) { throw; }
         }
 
-        [HttpPost("")]
+        [HttpPost("refresh")]
         public IActionResult Refresh(RefreshRequest request)
         {
             try { return Ok(auth.Refresh(request)); }


### PR DESCRIPTION
In this version, AuthRequest and RefreshRequest are not inheriting from AuthRequest any more.
This is to clarify Swagger documentation removing unused properties in login and refresh endpoint.